### PR TITLE
add(I*VirtualObject): Add interfaces for all Vob types.

### DIFF
--- a/ZenKit/Vobs/Animate.cs
+++ b/ZenKit/Vobs/Animate.cs
@@ -2,7 +2,12 @@ using System;
 
 namespace ZenKit.Vobs
 {
-	public class Animate : VirtualObject
+	public interface IAnimate : IVirtualObject
+	{
+		bool StartOn { get; set; }
+	}
+
+	public class Animate : VirtualObject, IAnimate
 	{
 		public Animate() : base(Native.ZkVirtualObject_new(VirtualObjectType.zCVobAnimate))
 		{

--- a/ZenKit/Vobs/CodeMaster.cs
+++ b/ZenKit/Vobs/CodeMaster.cs
@@ -5,7 +5,22 @@ using ZenKit.Util;
 
 namespace ZenKit.Vobs
 {
-	public class CodeMaster : VirtualObject
+	public interface ICodeMaster : IVirtualObject
+	{
+		string Target { get; set; }
+		bool Ordered { get; set; }
+		bool FirstFalseIsFailure { get; set; }
+		string FailureTarget { get; set; }
+		bool UntriggeredCancels { get; set; }
+		int SlaveCount { get; }
+		List<string> Slaves { get; }
+		string GetSlave(int i);
+		void AddSlave(string slave);
+		void RemoveSlave(int i);
+		void RemoveSlaves(Predicate<string> pred);
+	}
+
+	public class CodeMaster : VirtualObject, ICodeMaster
 	{
 		private static readonly Native.Callbacks.ZkStringEnumerator RemoveSlavesEnumerator = _enumerateSlavesHandler;
 

--- a/ZenKit/Vobs/Container.cs
+++ b/ZenKit/Vobs/Container.cs
@@ -10,7 +10,7 @@ namespace ZenKit.Vobs
 		string PickString { get; set; }
 		string Contents { get; set; }
 		int ItemCount { get; }
-		List<Item> Items { get; }
+		List<IItem> Items { get; }
 		void AddItem(Item item);
 		void RemoveItem(int i);
 	}
@@ -61,11 +61,11 @@ namespace ZenKit.Vobs
 
 		public int ItemCount => (int)Native.ZkContainer_getItemCount(Handle);
 
-		public List<Item> Items
+		public List<IItem> Items
 		{
 			get
 			{
-				var items = new List<Item>();
+				var items = new List<IItem>();
 
 				for (var i = 0; i < ItemCount; ++i)
 				{

--- a/ZenKit/Vobs/Container.cs
+++ b/ZenKit/Vobs/Container.cs
@@ -3,7 +3,19 @@ using System.Collections.Generic;
 
 namespace ZenKit.Vobs
 {
-	public class Container : InteractiveObject
+	public interface IContainer : IInteractiveObject
+	{
+		bool IsLocked { get; set; }
+		string Key { get; set; }
+		string PickString { get; set; }
+		string Contents { get; set; }
+		int ItemCount { get; }
+		List<Item> Items { get; }
+		void AddItem(Item item);
+		void RemoveItem(int i);
+	}
+
+	public class Container : InteractiveObject, IContainer
 	{
 		public Container() : base(Native.ZkVirtualObject_new(VirtualObjectType.oCMobContainer))
 		{

--- a/ZenKit/Vobs/CutsceneCamera.cs
+++ b/ZenKit/Vobs/CutsceneCamera.cs
@@ -165,8 +165,8 @@ namespace ZenKit.Vobs
 		int PositionCount { get; }
 		int TargetCount { get; }
 		int FrameCount { get; }
-		List<CameraTrajectoryFrame> Frames { get; }
-		CameraTrajectoryFrame GetFrame(int i);
+		List<ICameraTrajectoryFrame> Frames { get; }
+		ICameraTrajectoryFrame GetFrame(int i);
 	}
 
 	public class CutsceneCamera : VirtualObject, ICutsceneCamera
@@ -279,11 +279,11 @@ namespace ZenKit.Vobs
 		public int TargetCount => Native.ZkCutsceneCamera_getTargetCount(Handle);
 		public int FrameCount => (int)Native.ZkCutsceneCamera_getFrameCount(Handle);
 
-		public List<CameraTrajectoryFrame> Frames
+		public List<ICameraTrajectoryFrame> Frames
 		{
 			get
 			{
-				var frames = new List<CameraTrajectoryFrame>();
+				var frames = new List<ICameraTrajectoryFrame>();
 				var count = FrameCount;
 				for (var i = 0; i < count; ++i) frames.Add(GetFrame(i));
 				return frames;
@@ -295,7 +295,7 @@ namespace ZenKit.Vobs
 			Native.ZkCutsceneCamera_del(Handle);
 		}
 
-		public CameraTrajectoryFrame GetFrame(int i)
+		public ICameraTrajectoryFrame GetFrame(int i)
 		{
 			var handle = Native.ZkCutsceneCamera_getFrame(Handle, (ulong)i);
 			return new CameraTrajectoryFrame(Native.ZkObject_takeRef(handle));

--- a/ZenKit/Vobs/CutsceneCamera.cs
+++ b/ZenKit/Vobs/CutsceneCamera.cs
@@ -36,7 +36,24 @@ namespace ZenKit.Vobs
 		Custom = 6
 	}
 
-	public class CameraTrajectoryFrame : VirtualObject
+	public interface ICameraTrajectoryFrame : IVirtualObject
+	{
+		float Time { get; set; }
+		float RollAngle { get; set; }
+		float FovScale { get; set; }
+		CameraMotion MotionType { get; set; }
+		CameraMotion MotionTypeFov { get; set; }
+		CameraMotion MotionTypeRoll { get; set; }
+		CameraMotion MotionTypeTimeScale { get; set; }
+		float Tension { get; set; }
+		float CamBias { get; set; }
+		float Continuity { get; set; }
+		float TimeScale { get; set; }
+		bool TimeFixed { get; set; }
+		Matrix4x4 OriginalPose { get; set; }
+	}
+
+	public class CameraTrajectoryFrame : VirtualObject, ICameraTrajectoryFrame
 	{
 		public CameraTrajectoryFrame() : base(Native.ZkVirtualObject_new(VirtualObjectType.zCCamTrj_KeyFrame))
 		{
@@ -129,7 +146,30 @@ namespace ZenKit.Vobs
 		}
 	}
 
-	public class CutsceneCamera : VirtualObject
+	public interface ICutsceneCamera : IVirtualObject
+	{
+		CameraTrajectory TrajectoryFOR { get; set; }
+		CameraTrajectory TargetTrajectoryFOR { get; set; }
+		CameraLoopType LoopMode { get; set; }
+		CameraLerpType LerpMode { get; set; }
+		bool IgnoreFORVobRotation { get; set; }
+		bool IgnoreFORVobRotationTarget { get; set; }
+		bool Adapt { get; set; }
+		bool EaseFirst { get; set; }
+		bool EaseLast { get; set; }
+		float TotalDuration { get; set; }
+		string AutoFocusVob { get; set; }
+		bool AutoPlayerMovable { get; set; }
+		bool AutoUntriggerLast { get; set; }
+		float AutoUntriggerLastDelay { get; set; }
+		int PositionCount { get; }
+		int TargetCount { get; }
+		int FrameCount { get; }
+		List<CameraTrajectoryFrame> Frames { get; }
+		CameraTrajectoryFrame GetFrame(int i);
+	}
+
+	public class CutsceneCamera : VirtualObject, ICutsceneCamera
 	{
 		public CutsceneCamera() : base(Native.ZkVirtualObject_new(VirtualObjectType.zCCSCamera))
 		{

--- a/ZenKit/Vobs/Door.cs
+++ b/ZenKit/Vobs/Door.cs
@@ -2,7 +2,14 @@ using System;
 
 namespace ZenKit.Vobs
 {
-	public class Door : InteractiveObject
+	public interface IDoor : IInteractiveObject
+	{
+		bool IsLocked { get; set; }
+		string Key { get; set; }
+		string PickString { get; set; }
+	}
+
+	public class Door : InteractiveObject, IDoor
 	{
 		public Door() : base(Native.ZkVirtualObject_new(VirtualObjectType.oCMobDoor))
 		{

--- a/ZenKit/Vobs/Earthquake.cs
+++ b/ZenKit/Vobs/Earthquake.cs
@@ -3,7 +3,14 @@ using System.Numerics;
 
 namespace ZenKit.Vobs
 {
-	public class Earthquake : VirtualObject
+	public interface IEarthquake : IVirtualObject
+	{
+		float Radius { get; set; }
+		TimeSpan Duration { get; set; }
+		Vector3 Amplitude { get; set; }
+	}
+
+	public class Earthquake : VirtualObject, IEarthquake
 	{
 		public Earthquake() : base(Native.ZkVirtualObject_new(VirtualObjectType.zCEarthquake))
 		{

--- a/ZenKit/Vobs/Fire.cs
+++ b/ZenKit/Vobs/Fire.cs
@@ -2,7 +2,13 @@ using System;
 
 namespace ZenKit.Vobs
 {
-	public class Fire : InteractiveObject
+	public interface IFire : IInteractiveObject
+	{
+		string Slot { get; set; }
+		string VobTree { get; set; }
+	}
+
+	public class Fire : InteractiveObject, IFire
 	{
 		public Fire() : base(Native.ZkVirtualObject_new(VirtualObjectType.oCMobFire))
 		{

--- a/ZenKit/Vobs/InteractiveObject.cs
+++ b/ZenKit/Vobs/InteractiveObject.cs
@@ -2,7 +2,17 @@ using System;
 
 namespace ZenKit.Vobs
 {
-	public class InteractiveObject : MovableObject
+	public interface IInteractiveObject : IMovableObject
+	{
+		int State { get; set; }
+		string Target { get; set; }
+		string Item { get; set; }
+		string ConditionFunction { get; set; }
+		string OnStateChangeFunction { get; set; }
+		bool Rewind { get; set; }
+	}
+
+	public class InteractiveObject : MovableObject, IInteractiveObject
 	{
 		public InteractiveObject() : base(Native.ZkVirtualObject_new(VirtualObjectType.oCMobInter))
 		{
@@ -69,7 +79,11 @@ namespace ZenKit.Vobs
 		}
 	}
 
-	public class Bed : InteractiveObject
+	public interface IBed : IInteractiveObject
+	{
+	}
+
+	public class Bed : InteractiveObject, IBed
 	{
 		public Bed() : base(Native.ZkVirtualObject_new(VirtualObjectType.oCMobBed))
 		{
@@ -80,7 +94,11 @@ namespace ZenKit.Vobs
 		}
 	}
 
-	public class Ladder : InteractiveObject
+	public interface ILadder : IInteractiveObject
+	{
+	}
+
+	public class Ladder : InteractiveObject, ILadder
 	{
 		public Ladder() : base(Native.ZkVirtualObject_new(VirtualObjectType.oCMobLadder))
 		{
@@ -91,7 +109,11 @@ namespace ZenKit.Vobs
 		}
 	}
 
-	public class Switch : InteractiveObject
+	public interface ISwitch : IInteractiveObject
+	{
+	}
+
+	public class Switch : InteractiveObject, ISwitch
 	{
 		public Switch() : base(Native.ZkVirtualObject_new(VirtualObjectType.oCMobSwitch))
 		{
@@ -102,7 +124,11 @@ namespace ZenKit.Vobs
 		}
 	}
 
-	public class Wheel : InteractiveObject
+	public interface IWheel : IInteractiveObject
+	{
+	}
+
+	public class Wheel : InteractiveObject, IWheel
 	{
 		public Wheel() : base(Native.ZkVirtualObject_new(VirtualObjectType.oCMobWheel))
 		{

--- a/ZenKit/Vobs/Item.cs
+++ b/ZenKit/Vobs/Item.cs
@@ -2,7 +2,14 @@ using System;
 
 namespace ZenKit.Vobs
 {
-	public class Item : VirtualObject
+	public interface IItem : IVirtualObject
+	{
+		string Instance { get; set; }
+		int Amount { get; set; }
+		int Flags { get; set; }
+	}
+
+	public class Item : VirtualObject, IItem
 	{
 		public Item() : base(Native.ZkVirtualObject_new(VirtualObjectType.oCItem))
 		{

--- a/ZenKit/Vobs/LensFlare.cs
+++ b/ZenKit/Vobs/LensFlare.cs
@@ -2,7 +2,12 @@ using System;
 
 namespace ZenKit.Vobs
 {
-	public class LensFlare : VirtualObject
+	public interface ILensFlare : IVirtualObject
+	{
+		string Effect { get; set; }
+	}
+
+	public class LensFlare : VirtualObject, ILensFlare
 	{
 		public LensFlare() : base(Native.ZkVirtualObject_new(VirtualObjectType.zCVobLensFlare))
 		{

--- a/ZenKit/Vobs/Light.cs
+++ b/ZenKit/Vobs/Light.cs
@@ -180,7 +180,12 @@ namespace ZenKit.Vobs
 		}
 	}
 
-	public class Light : VirtualObject, ILightPreset
+	public interface ILight : ILightPreset, IVirtualObject
+	{
+		
+	}
+
+	public class Light : VirtualObject, ILight
 	{
 		public Light() : base(Native.ZkVirtualObject_new(VirtualObjectType.zCVobLight))
 		{

--- a/ZenKit/Vobs/MessageFilter.cs
+++ b/ZenKit/Vobs/MessageFilter.cs
@@ -12,7 +12,14 @@ namespace ZenKit.Vobs
 		Toggle = 5
 	}
 
-	public class MessageFilter : VirtualObject
+	public interface IMessageFilter : IVirtualObject
+	{
+		string Target { get; set; }
+		MessageFilterAction OnTrigger { get; set; }
+		MessageFilterAction OnUntrigger { get; set; }
+	}
+
+	public class MessageFilter : VirtualObject, IMessageFilter
 	{
 		public MessageFilter() : base(Native.ZkVirtualObject_new(VirtualObjectType.zCMessageFilter))
 		{

--- a/ZenKit/Vobs/MovableObject.cs
+++ b/ZenKit/Vobs/MovableObject.cs
@@ -12,7 +12,22 @@ namespace ZenKit.Vobs
 		Glass = 5
 	}
 
-	public class MovableObject : VirtualObject
+	public interface IMovableObject : IVirtualObject
+	{
+		string FocusName { get; set; }
+		int Hp { get; set; }
+		int Damage { get; set; }
+		bool Movable { get; set; }
+		bool Takable { get; set; }
+		bool FocusOverride { get; set; }
+		SoundMaterialType Material { get; set; }
+		string VisualDestroyed { get; set; }
+		string Owner { get; set; }
+		string OwnerGuild { get; set; }
+		bool Destroyed { get; set; }
+	}
+
+	public class MovableObject : VirtualObject, IMovableObject
 	{
 		public MovableObject() : base(Native.ZkVirtualObject_new(VirtualObjectType.oCMOB))
 		{

--- a/ZenKit/Vobs/Mover.cs
+++ b/ZenKit/Vobs/Mover.cs
@@ -30,7 +30,39 @@ namespace ZenKit.Vobs
 		SegmentSlowEnd = 6
 	}
 
-	public class Mover : Trigger
+	public interface IMover : ITrigger
+	{
+		MoverBehavior Behavior { get; set; }
+		float TouchBlockerDamage { get; set; }
+		TimeSpan StayOpenTime { get; set; }
+		bool IsLocked { get; set; }
+		bool AutoLink { get; set; }
+		bool AutoRotate { get; set; }
+		float Speed { get; set; }
+		MoverLerpType LerpType { get; set; }
+		MoverSpeedType SpeedType { get; set; }
+		Vector3 ActKeyPosDelta { get; set; }
+		float ActKeyframeF { get; set; }
+		int ActKeyframe { get; set; }
+		int NextKeyframe { get; set; }
+		float MoveSpeedUnit { get; set; }
+		float AdvanceDir { get; set; }
+		int MoverState { get; set; }
+		int TriggerEventCount { get; set; }
+		float StayOpenTimeDest { get; set; }
+		int KeyframeCount { get; }
+		List<AnimationSample> Keyframes { get; }
+		string SfxOpenStart { get; set; }
+		string SfxOpenEnd { get; set; }
+		string SfxTransitioning { get; set; }
+		string SfxCloseStart { get; set; }
+		string SfxCloseEnd { get; set; }
+		string SfxLock { get; set; }
+		string SfxUnlock { get; set; }
+		string SfxUseLocked { get; set; }
+	}
+
+	public class Mover : Trigger, IMover
 	{
 		public Mover() : base(Native.ZkVirtualObject_new(VirtualObjectType.zCMover))
 		{

--- a/ZenKit/Vobs/MoverController.cs
+++ b/ZenKit/Vobs/MoverController.cs
@@ -10,7 +10,14 @@ namespace ZenKit.Vobs
 		Previous = 3
 	}
 
-	public class MoverController : VirtualObject
+	public interface IMoverController : IVirtualObject
+	{
+		string Target { get; set; }
+		MoverMessageType Message { get; set; }
+		int Key { get; set; }
+	}
+
+	public class MoverController : VirtualObject, IMoverController
 	{
 		public MoverController() : base(Native.ZkVirtualObject_new(VirtualObjectType.zCMoverController))
 		{

--- a/ZenKit/Vobs/Npc.cs
+++ b/ZenKit/Vobs/Npc.cs
@@ -73,7 +73,7 @@ namespace ZenKit.Vobs
 	{
 		bool Used { get; set; }
 		string Name { get; set; }
-		Item? Item { get; set; }
+		IItem? Item { get; set; }
 		bool InInventory { get; set; }
 	}
 
@@ -99,14 +99,14 @@ namespace ZenKit.Vobs
 			set => Native.ZkNpcSlot_setName(handle, value);
 		}
 
-		public Item? Item
+		public IItem? Item
 		{
 			get
 			{
 				var val = Native.ZkNpcSlot_getItem(handle);
 				return val == UIntPtr.Zero ? null : new Item(Native.ZkObject_takeRef(val));
 			}
-			set => Native.ZkNpcSlot_setItem(handle, value?.Handle ?? UIntPtr.Zero);
+			set => Native.ZkNpcSlot_setItem(handle, value == null ? UIntPtr.Zero : ((Item)value).Handle);
 		}
 
 		public bool InInventory
@@ -242,18 +242,18 @@ namespace ZenKit.Vobs
 		int BsInterruptableOverride { get; set; }
 		int NpcType { get; set; }
 		int SpellMana { get; set; }
-		VirtualObject? CarryVob { get; set; }
-		VirtualObject? Enemy { get; set; }
+		IVirtualObject? CarryVob { get; set; }
+		IVirtualObject? Enemy { get; set; }
 		int OverlayCount { get; }
 		List<string> Overlays { get; set; }
 		int TalentCount { get; }
-		List<Talent> Talents { get; set; }
+		List<ITalent> Talents { get; set; }
 		int ItemCount { get; }
-		List<Item> Items { get; set; }
+		List<IItem> Items { get; set; }
 		int SlotCount { get; }
-		List<Slot> Slots { get; }
+		List<ISlot> Slots { get; }
 		int NewsCount { get; }
-		List<News> News { get; }
+		List<INews> News { get; }
 		List<int> Protection { get; set; }
 		List<int> Attributes { get; set; }
 		List<int> HitChance { get; set; }
@@ -265,24 +265,24 @@ namespace ZenKit.Vobs
 		void RemoveOverlay(int i);
 		void SetOverlay(int i, string overlay);
 		void AddOverlay(string overlay);
-		Talent GetTalent(int i);
+		ITalent GetTalent(int i);
 		void ClearTalents();
 		void RemoveTalent(int i);
-		void SetTalent(int i, Talent talent);
-		void AddTalent(Talent talent);
-		Item GetItem(int i);
+		void SetTalent(int i, ITalent talent);
+		void AddTalent(ITalent talent);
+		IItem GetItem(int i);
 		void ClearItems();
 		void RemoveItem(int i);
-		void SetItem(int i, Item item);
-		void AddItem(Item item);
-		Slot GetSlot(int i);
+		void SetItem(int i, IItem item);
+		void AddItem(IItem item);
+		ISlot GetSlot(int i);
 		void ClearSlots();
 		void RemoveSlot(int i);
-		Slot AddSlot();
-		News GetNews(int i);
+		ISlot AddSlot();
+		INews GetNews(int i);
 		void ClearNews();
 		void RemoveNews(int i);
-		News AddNews();
+		INews AddNews();
 		int GetProtection(int i);
 		void SetProtection(int i, int v);
 		int GetAttribute(int i);
@@ -581,24 +581,24 @@ namespace ZenKit.Vobs
 			set => Native.ZkNpc_setSpellMana(Handle, value);
 		}
 
-		public VirtualObject? CarryVob
+		public IVirtualObject? CarryVob
 		{
 			get
 			{
 				var val = Native.ZkNpc_getCarryVob(Handle);
 				return VirtualObject.FromNative(Native.ZkObject_takeRef(val));
 			}
-			set => Native.ZkNpc_setCarryVob(Handle, value?.Handle ?? System.UIntPtr.Zero);
+			set => Native.ZkNpc_setCarryVob(Handle, value == null ? UIntPtr.Zero : ((VirtualObject)value).Handle);
 		}
 
-		public VirtualObject? Enemy
+		public IVirtualObject? Enemy
 		{
 			get
 			{
 				var val = Native.ZkNpc_getEnemy(Handle);
 				return VirtualObject.FromNative(Native.ZkObject_takeRef(val));
 			}
-			set => Native.ZkNpc_setEnemy(Handle, value?.Handle ?? System.UIntPtr.Zero);
+			set => Native.ZkNpc_setEnemy(Handle, value == null ? UIntPtr.Zero : ((VirtualObject)value).Handle);
 		}
 
 
@@ -653,11 +653,11 @@ namespace ZenKit.Vobs
 
 		public int TalentCount => (int)Native.ZkNpc_getTalentCount(Handle);
 
-		public List<Talent> Talents
+		public List<ITalent> Talents
 		{
 			get
 			{
-				var talents = new List<Talent>();
+				var talents = new List<ITalent>();
 
 				for (var i = 0; i < TalentCount; ++i)
 				{
@@ -675,7 +675,7 @@ namespace ZenKit.Vobs
 		}
 
 
-		public Talent GetTalent(int i)
+		public ITalent GetTalent(int i)
 		{
 			return new Talent(Native.ZkObject_takeRef(Native.ZkNpc_getTalent(Handle, (ulong)i)));
 		}
@@ -690,23 +690,23 @@ namespace ZenKit.Vobs
 			Native.ZkNpc_removeTalent(Handle, (ulong)i);
 		}
 
-		public void SetTalent(int i, Talent talent)
+		public void SetTalent(int i, ITalent talent)
 		{
-			Native.ZkNpc_setTalent(Handle, (ulong)i, talent.Handle);
+			Native.ZkNpc_setTalent(Handle, (ulong)i, ((Talent)talent).Handle);
 		}
 
-		public void AddTalent(Talent talent)
+		public void AddTalent(ITalent talent)
 		{
-			Native.ZkNpc_addTalent(Handle, talent.Handle);
+			Native.ZkNpc_addTalent(Handle, ((Talent)talent).Handle);
 		}
 
 		public int ItemCount => (int)Native.ZkNpc_getItemCount(Handle);
 
-		public List<Item> Items
+		public List<IItem> Items
 		{
 			get
 			{
-				var items = new List<Item>();
+				var items = new List<IItem>();
 
 				for (var i = 0; i < ItemCount; ++i)
 				{
@@ -723,7 +723,7 @@ namespace ZenKit.Vobs
 		}
 
 
-		public Item GetItem(int i)
+		public IItem GetItem(int i)
 		{
 			return new Item(Native.ZkObject_takeRef(Native.ZkNpc_getItem(Handle, (ulong)i)));
 		}
@@ -738,23 +738,23 @@ namespace ZenKit.Vobs
 			Native.ZkNpc_removeItem(Handle, (ulong)i);
 		}
 
-		public void SetItem(int i, Item item)
+		public void SetItem(int i, IItem item)
 		{
-			Native.ZkNpc_setItem(Handle, (ulong)i, item.Handle);
+			Native.ZkNpc_setItem(Handle, (ulong)i, ((Item)item).Handle);
 		}
 
-		public void AddItem(Item item)
+		public void AddItem(IItem item)
 		{
-			Native.ZkNpc_addItem(Handle, item.Handle);
+			Native.ZkNpc_addItem(Handle, ((Item)item).Handle);
 		}
 
 		public int SlotCount => (int)Native.ZkNpc_getSlotCount(Handle);
 
-		public List<Slot> Slots
+		public List<ISlot> Slots
 		{
 			get
 			{
-				var items = new List<Slot>();
+				var items = new List<ISlot>();
 
 				for (var i = 0; i < ItemCount; ++i)
 				{
@@ -765,7 +765,7 @@ namespace ZenKit.Vobs
 			}
 		}
 
-		public Slot GetSlot(int i)
+		public ISlot GetSlot(int i)
 		{
 			return new Slot(Native.ZkNpc_getSlot(Handle, (ulong)i));
 		}
@@ -780,18 +780,18 @@ namespace ZenKit.Vobs
 			Native.ZkNpc_removeSlot(Handle, (ulong)i);
 		}
 
-		public Slot AddSlot()
+		public ISlot AddSlot()
 		{
 			return new Slot(Native.ZkNpc_addSlot(Handle));
 		}
 
 		public int NewsCount => (int)Native.ZkNpc_getNewsCount(Handle);
 
-		public List<News> News
+		public List<INews> News
 		{
 			get
 			{
-				var items = new List<News>();
+				var items = new List<INews>();
 
 				for (var i = 0; i < ItemCount; ++i)
 				{
@@ -802,7 +802,7 @@ namespace ZenKit.Vobs
 			}
 		}
 
-		public News GetNews(int i)
+		public INews GetNews(int i)
 		{
 			return new News(Native.ZkNpc_getNews(Handle, (ulong)i));
 		}
@@ -817,7 +817,7 @@ namespace ZenKit.Vobs
 			Native.ZkNpc_removeSlot(Handle, (ulong)i);
 		}
 
-		public News AddNews()
+		public INews AddNews()
 		{
 			return new News(Native.ZkNpc_addNews(Handle));
 		}

--- a/ZenKit/Vobs/Npc.cs
+++ b/ZenKit/Vobs/Npc.cs
@@ -24,7 +24,14 @@ namespace ZenKit.Vobs
 		HasDefeated = 170,
 	}
 
-	public class Talent
+	public interface ITalent
+	{
+		int Type { get; set; }
+		int Value { get; set; }
+		int Skill { get; set; }
+	}
+
+	public class Talent : ITalent
 	{
 		internal readonly UIntPtr Handle;
 
@@ -62,7 +69,15 @@ namespace ZenKit.Vobs
 		}
 	}
 
-	public class Slot
+	public interface ISlot
+	{
+		bool Used { get; set; }
+		string Name { get; set; }
+		Item? Item { get; set; }
+		bool InInventory { get; set; }
+	}
+
+	public class Slot : ISlot
 	{
 		private readonly UIntPtr handle;
 
@@ -101,7 +116,20 @@ namespace ZenKit.Vobs
 		}
 	}
 
-	public class News
+	public interface INews
+	{
+		bool Told { get; set; }
+		float SpreadTime { get; set; }
+		NpcNewsSpread SpreadType { get; set; }
+		NpcNewsId NewsId { get; set; }
+		bool Gossip { get; set; }
+		bool GuildVictim { get; set; }
+		string WitnessName { get; set; }
+		string OffenderName { get; set; }
+		string VictimName { get; set; }
+	}
+
+	public class News : INews
 	{
 		private readonly UIntPtr handle;
 
@@ -166,7 +194,108 @@ namespace ZenKit.Vobs
 		}
 	}
 
-	public class Npc : VirtualObject
+	public interface INpc : IVirtualObject
+	{
+		string NpcInstance { get; set; }
+		Vector3 ModelScale { get; set; }
+		float ModelFatness { get; set; }
+		int Flags { get; set; }
+		int Guild { get; set; }
+		int GuildTrue { get; set; }
+		int Level { get; set; }
+		int Xp { get; set; }
+		int XpNextLevel { get; set; }
+		int Lp { get; set; }
+		int FightTactic { get; set; }
+		int FightMode { get; set; }
+		bool Wounded { get; set; }
+		bool Mad { get; set; }
+		int MadTime { get; set; }
+		bool Player { get; set; }
+		string StartAiState { get; set; }
+		string ScriptWaypoint { get; set; }
+		int Attitude { get; set; }
+		int AttitudeTemp { get; set; }
+		int NameNr { get; set; }
+		bool MoveLock { get; set; }
+		bool CurrentStateValid { get; set; }
+		string CurrentStateName { get; set; }
+		int CurrentStateIndex { get; set; }
+		bool CurrentStateIsRoutine { get; set; }
+		bool NextStateValid { get; set; }
+		string NextStateName { get; set; }
+		int NextStateIndex { get; set; }
+		bool NextStateIsRoutine { get; set; }
+		int LastAiState { get; set; }
+		bool HasRoutine { get; set; }
+		bool RoutineChanged { get; set; }
+		bool RoutineOverlay { get; set; }
+		int RoutineOverlayCount { get; set; }
+		int WalkmodeRoutine { get; set; }
+		bool WeaponmodeRoutine { get; set; }
+		bool StartNewRoutine { get; set; }
+		int AiStateDriven { get; set; }
+		Vector3 AiStatePos { get; set; }
+		string CurrentRoutine { get; set; }
+		bool Respawn { get; set; }
+		int RespawnTime { get; set; }
+		int BsInterruptableOverride { get; set; }
+		int NpcType { get; set; }
+		int SpellMana { get; set; }
+		VirtualObject? CarryVob { get; set; }
+		VirtualObject? Enemy { get; set; }
+		int OverlayCount { get; }
+		List<string> Overlays { get; set; }
+		int TalentCount { get; }
+		List<Talent> Talents { get; set; }
+		int ItemCount { get; }
+		List<Item> Items { get; set; }
+		int SlotCount { get; }
+		List<Slot> Slots { get; }
+		int NewsCount { get; }
+		List<News> News { get; }
+		List<int> Protection { get; set; }
+		List<int> Attributes { get; set; }
+		List<int> HitChance { get; set; }
+		List<int> Missions { get; set; }
+		int[] AiVars { get; set; }
+		List<string> Packed { get; set; }
+		string GetOverlay(int i);
+		void ClearOverlays();
+		void RemoveOverlay(int i);
+		void SetOverlay(int i, string overlay);
+		void AddOverlay(string overlay);
+		Talent GetTalent(int i);
+		void ClearTalents();
+		void RemoveTalent(int i);
+		void SetTalent(int i, Talent talent);
+		void AddTalent(Talent talent);
+		Item GetItem(int i);
+		void ClearItems();
+		void RemoveItem(int i);
+		void SetItem(int i, Item item);
+		void AddItem(Item item);
+		Slot GetSlot(int i);
+		void ClearSlots();
+		void RemoveSlot(int i);
+		Slot AddSlot();
+		News GetNews(int i);
+		void ClearNews();
+		void RemoveNews(int i);
+		News AddNews();
+		int GetProtection(int i);
+		void SetProtection(int i, int v);
+		int GetAttribute(int i);
+		void SetAttribute(int i, int v);
+		int GetHitChance(int i);
+		void SetHitChance(int i, int v);
+		int GetMission(int i);
+		void SetMission(int i, int v);
+		string GetPacked(int i);
+		void SetPacked(int i, string v);
+	}
+
+	public class Npc : VirtualObject, INpc
 	{
 		public Npc() : base(Native.ZkVirtualObject_new(VirtualObjectType.oCNpc))
 		{

--- a/ZenKit/Vobs/ParticleEffectController.cs
+++ b/ZenKit/Vobs/ParticleEffectController.cs
@@ -2,7 +2,14 @@ using System;
 
 namespace ZenKit.Vobs
 {
-	public class ParticleEffectController : VirtualObject
+	public interface IParticleEffectController : IVirtualObject
+	{
+		string EffectName { get; set; }
+		bool KillWhenDone { get; set; }
+		bool InitiallyRunning { get; set; }
+	}
+
+	public class ParticleEffectController : VirtualObject, IParticleEffectController
 	{
 		public ParticleEffectController() : base(Native.ZkVirtualObject_new(VirtualObjectType.zCPFXController))
 		{

--- a/ZenKit/Vobs/Sound.cs
+++ b/ZenKit/Vobs/Sound.cs
@@ -15,7 +15,24 @@ namespace ZenKit.Vobs
 		Ellipsoidal = 1
 	}
 
-	public class Sound : VirtualObject
+	public interface ISound : IVirtualObject
+	{
+		float Volume { get; set; }
+		SoundMode Mode { get; set; }
+		float RandomDelay { get; set; }
+		float RandomDelayVar { get; set; }
+		bool InitiallyPlaying { get; set; }
+		bool Ambient3d { get; set; }
+		bool Obstruction { get; set; }
+		float ConeAngle { get; set; }
+		SoundTriggerVolumeType VolumeType { get; set; }
+		float Radius { get; set; }
+		string SoundName { get; set; }
+		bool IsRunning { get; set; }
+		bool IsAllowedToRun { get; set; }
+	}
+
+	public class Sound : VirtualObject, ISound
 	{
 		public Sound() : base(Native.ZkVirtualObject_new(VirtualObjectType.zCVobSound))
 		{
@@ -119,7 +136,14 @@ namespace ZenKit.Vobs
 		}
 	}
 
-	public class SoundDaytime : Sound
+	public interface ISoundDaytime : ISound
+	{
+		float StartTime { get; set; }
+		float EndTime { get; set; }
+		string SoundNameDaytime { get; set; }
+	}
+
+	public class SoundDaytime : Sound, ISoundDaytime
 	{
 		public SoundDaytime() : base(Native.ZkVirtualObject_new(VirtualObjectType.zCVobSoundDaytime))
 		{

--- a/ZenKit/Vobs/TouchDamage.cs
+++ b/ZenKit/Vobs/TouchDamage.cs
@@ -9,7 +9,23 @@ namespace ZenKit.Vobs
 		Point = 2
 	}
 
-	public class TouchDamage : VirtualObject
+	public interface ITouchDamage : IVirtualObject
+	{
+		float Damage { get; set; }
+		bool IsBarrier { get; set; }
+		bool IsBlunt { get; set; }
+		bool IsEdge { get; set; }
+		bool IsFire { get; set; }
+		bool IsFly { get; set; }
+		bool IsMagic { get; set; }
+		bool IsPoint { get; set; }
+		bool IsFall { get; set; }
+		TimeSpan RepeatDelay { get; set; }
+		float VolumeScale { get; set; }
+		TouchCollisionType CollisionType { get; set; }
+	}
+
+	public class TouchDamage : VirtualObject, ITouchDamage
 	{
 		public TouchDamage() : base(Native.ZkVirtualObject_new(VirtualObjectType.oCTouchDamage))
 		{

--- a/ZenKit/Vobs/Trigger.cs
+++ b/ZenKit/Vobs/Trigger.cs
@@ -19,7 +19,7 @@ namespace ZenKit.Vobs
 		float DamageThreshold { get; set; }
 		TimeSpan FireDelay { get; set; }
 		float NextTimeTriggerable { get; set; }
-		VirtualObject? OtherVob { get; set; }
+		IVirtualObject? OtherVob { get; set; }
 		int CountCanBeActivated { get; set; }
 		bool IsEnabled { get; set; }
 	}
@@ -134,14 +134,14 @@ namespace ZenKit.Vobs
 			set => Native.ZkTrigger_setNextTimeTriggerable(Handle, value);
 		}
 
-		public VirtualObject? OtherVob
+		public IVirtualObject? OtherVob
 		{
 			get
 			{
 				var val = Native.ZkTrigger_getOtherVob(Handle);
 				return VirtualObject.FromNative(Native.ZkObject_takeRef(val));
 			}
-			set => Native.ZkTrigger_setOtherVob(Handle, value?.Handle ?? UIntPtr.Zero);
+			set => Native.ZkTrigger_setOtherVob(Handle, value == null ? UIntPtr.Zero : ((VirtualObject)value).Handle);
 		}
 
 		public int CountCanBeActivated

--- a/ZenKit/Vobs/Trigger.cs
+++ b/ZenKit/Vobs/Trigger.cs
@@ -2,7 +2,29 @@ using System;
 
 namespace ZenKit.Vobs
 {
-	public class Trigger : VirtualObject
+	public interface ITrigger : IVirtualObject
+	{
+		string Target { get; set; }
+		bool StartEnabled { get; set; }
+		bool SendUntrigger { get; set; }
+		bool ReactToOnTrigger { get; set; }
+		bool ReactToOnTouch { get; set; }
+		bool ReactToOnDamage { get; set; }
+		bool RespondToObject { get; set; }
+		bool RespondToPC { get; set; }
+		bool RespondToNPC { get; set; }
+		string VobTarget { get; set; }
+		int MaxActivationCount { get; set; }
+		TimeSpan RetriggerDelay { get; set; }
+		float DamageThreshold { get; set; }
+		TimeSpan FireDelay { get; set; }
+		float NextTimeTriggerable { get; set; }
+		VirtualObject? OtherVob { get; set; }
+		int CountCanBeActivated { get; set; }
+		bool IsEnabled { get; set; }
+	}
+
+	public class Trigger : VirtualObject, ITrigger
 	{
 		public Trigger() : base(Native.ZkVirtualObject_new(VirtualObjectType.zCTrigger))
 		{
@@ -141,7 +163,11 @@ namespace ZenKit.Vobs
 		}
 	}
 
-	public class CutsceneTrigger : Trigger
+	public interface ICutsceneTrigger : ITrigger
+	{
+	}
+
+	public class CutsceneTrigger : Trigger, ICutsceneTrigger
 	{
 		public CutsceneTrigger(Read buf, GameVersion version) : base(buf, version)
 		{

--- a/ZenKit/Vobs/TriggerChangeLevel.cs
+++ b/ZenKit/Vobs/TriggerChangeLevel.cs
@@ -2,7 +2,13 @@ using System;
 
 namespace ZenKit.Vobs
 {
-	public class TriggerChangeLevel : Trigger
+	public interface ITriggerChangeLevel : ITrigger
+	{
+		string LevelName { get; set; }
+		string StartVob { get; set; }
+	}
+
+	public class TriggerChangeLevel : Trigger, ITriggerChangeLevel
 	{
 		public TriggerChangeLevel() : base(Native.ZkVirtualObject_new(VirtualObjectType.oCTriggerChangeLevel))
 		{

--- a/ZenKit/Vobs/TriggerScript.cs
+++ b/ZenKit/Vobs/TriggerScript.cs
@@ -2,7 +2,12 @@ using System;
 
 namespace ZenKit.Vobs
 {
-	public class TriggerScript : Trigger
+	public interface ITriggerScript : IVirtualObject
+	{
+		string Function { get; set; }
+	}
+
+	public class TriggerScript : Trigger, ITriggerScript
 	{
 		public TriggerScript() : base(Native.ZkVirtualObject_new(VirtualObjectType.oCTriggerScript))
 		{

--- a/ZenKit/Vobs/TriggerUntouch.cs
+++ b/ZenKit/Vobs/TriggerUntouch.cs
@@ -2,7 +2,12 @@ using System;
 
 namespace ZenKit.Vobs
 {
-	public class TriggerUntouch : VirtualObject
+	public interface ITriggerUntouch : IVirtualObject
+	{
+		string Target { get; set; }
+	}
+
+	public class TriggerUntouch : VirtualObject, ITriggerUntouch
 	{
 		public TriggerUntouch() : base(Native.ZkVirtualObject_new(VirtualObjectType.zCTriggerUntouch))
 		{

--- a/ZenKit/Vobs/TriggerWorldStart.cs
+++ b/ZenKit/Vobs/TriggerWorldStart.cs
@@ -2,7 +2,14 @@ using System;
 
 namespace ZenKit.Vobs
 {
-	public class TriggerWorldStart : VirtualObject
+	public interface ITriggerWorldStart : IVirtualObject
+	{
+		string Target { get; set; }
+		bool FireOnce { get; set; }
+		bool HasFired { get; set; }
+	}
+
+	public class TriggerWorldStart : VirtualObject, ITriggerWorldStart
 	{
 		public TriggerWorldStart() : base(Native.ZkVirtualObject_new(VirtualObjectType.zCTriggerWorldStart))
 		{

--- a/ZenKit/Vobs/VirtualObject.cs
+++ b/ZenKit/Vobs/VirtualObject.cs
@@ -155,7 +155,7 @@ namespace ZenKit.Vobs
 			Native.ZkVisual_del(Handle);
 		}
 
-		public static Visual? FromNative(UIntPtr ptr)
+		public static IVisual? FromNative(UIntPtr ptr)
 		{
 			if (ptr == UIntPtr.Zero) return null;
 
@@ -173,7 +173,11 @@ namespace ZenKit.Vobs
 		}
 	}
 
-	public class VisualMesh : Visual
+	public interface IVisualMesh : IVisual
+	{
+	}
+
+	public class VisualMesh : Visual, IVisualMesh
 	{
 		public VisualMesh() : base(Native.ZkVisual_new(VisualType.Mesh))
 		{
@@ -184,7 +188,11 @@ namespace ZenKit.Vobs
 		}
 	}
 
-	public class VisualMultiResolutionMesh : Visual
+	public interface IVisualMultiResolutionMesh : IVisual
+	{
+	}
+
+	public class VisualMultiResolutionMesh : Visual, IVisualMultiResolutionMesh
 	{
 		public VisualMultiResolutionMesh() : base(Native.ZkVisual_new(VisualType.MultiResolutionMesh))
 		{
@@ -195,7 +203,11 @@ namespace ZenKit.Vobs
 		}
 	}
 
-	public class VisualParticleEffect : Visual
+	public interface IVisualParticleEffect : IVisual
+	{
+	}
+
+	public class VisualParticleEffect : Visual, IVisualParticleEffect
 	{
 		public VisualParticleEffect() : base(Native.ZkVisual_new(VisualType.ParticleEffect))
 		{
@@ -206,7 +218,11 @@ namespace ZenKit.Vobs
 		}
 	}
 
-	public class VisualCamera : Visual
+	public interface IVisualCamera : IVisual
+	{
+	}
+
+	public class VisualCamera : Visual, IVisualCamera
 	{
 		public VisualCamera() : base(Native.ZkVisual_new(VisualType.Camera))
 		{
@@ -217,7 +233,11 @@ namespace ZenKit.Vobs
 		}
 	}
 
-	public class VisualModel : Visual
+	public interface IVisualModel : IVisual
+	{
+	}
+
+	public class VisualModel : Visual, IVisualModel
 	{
 		public VisualModel() : base(Native.ZkVisual_new(VisualType.Model))
 		{
@@ -228,7 +248,11 @@ namespace ZenKit.Vobs
 		}
 	}
 
-	public class VisualMorphMesh : Visual
+	public interface IVisualMorphMesh : IVisual
+	{
+	}
+
+	public class VisualMorphMesh : Visual, IVisualMorphMesh
 	{
 		public VisualMorphMesh() : base(Native.ZkVisual_new(VisualType.MorphMesh))
 		{
@@ -971,28 +995,44 @@ namespace ZenKit.Vobs
 		}
 	}
 
-	public class Spot : VirtualObject
+	public interface ISpot : IVirtualObject
+	{
+	}
+
+	public class Spot : VirtualObject, ISpot
 	{
 		internal Spot(UIntPtr handle) : base(handle)
 		{
 		}
 	}
 
-	public class Stair : VirtualObject
+	public interface IStair : IVirtualObject
+	{
+	}
+
+	public class Stair : VirtualObject, IStair
 	{
 		internal Stair(UIntPtr handle) : base(handle)
 		{
 		}
 	}
 
-	public class StartPoint : VirtualObject
+	public interface IStartPoint : IVirtualObject
+	{
+	}
+
+	public class StartPoint : VirtualObject, IStartPoint
 	{
 		internal StartPoint(UIntPtr handle) : base(handle)
 		{
 		}
 	}
 
-	public class Level : VirtualObject
+	public interface ILevel : IVirtualObject
+	{
+	}
+
+	public class Level : VirtualObject, ILevel
 	{
 		internal Level(UIntPtr handle) : base(handle)
 		{

--- a/ZenKit/Vobs/ZoneFarPlane.cs
+++ b/ZenKit/Vobs/ZoneFarPlane.cs
@@ -2,7 +2,13 @@ using System;
 
 namespace ZenKit.Vobs
 {
-	public class ZoneFarPlane : VirtualObject
+	public interface IZoneFarPlane : IVirtualObject
+	{
+		float VobFarPlaneZ { get; set; }
+		float InnerRangePercentage { get; set; }
+	}
+
+	public class ZoneFarPlane : VirtualObject, IZoneFarPlane
 	{
 		public ZoneFarPlane() : base(Native.ZkVirtualObject_new(VirtualObjectType.zCZoneVobFarPlane))
 		{
@@ -40,7 +46,11 @@ namespace ZenKit.Vobs
 		}
 	}
 
-	public class ZoneFarPlaneDefault : ZoneFarPlane
+	public interface IZoneFarPlaneDefault : IZoneFarPlane
+	{
+	}
+
+	public class ZoneFarPlaneDefault : ZoneFarPlane, IZoneFarPlaneDefault
 	{
 		public ZoneFarPlaneDefault(Read buf, GameVersion version) : base(buf, version)
 		{

--- a/ZenKit/Vobs/ZoneFog.cs
+++ b/ZenKit/Vobs/ZoneFog.cs
@@ -3,7 +3,16 @@ using System.Drawing;
 
 namespace ZenKit.Vobs
 {
-	public class ZoneFog : VirtualObject
+	public interface IZoneFog : IVirtualObject
+	{
+		float RangeCenter { get; set; }
+		float InnerRangePercentage { get; set; }
+		Color Color { get; set; }
+		bool FadeOutSky { get; set; }
+		bool OverrideColor { get; set; }
+	}
+
+	public class ZoneFog : VirtualObject, IZoneFog
 	{
 		public ZoneFog() : base(Native.ZkVirtualObject_new(VirtualObjectType.zCZoneZFog))
 		{
@@ -59,7 +68,11 @@ namespace ZenKit.Vobs
 		}
 	}
 
-	public class ZoneFogDefault : ZoneFog
+	public interface IZoneFogDefault : IZoneFog
+	{
+	}
+
+	public class ZoneFogDefault : ZoneFog, IZoneFogDefault
 	{
 		public ZoneFogDefault() : base(Native.ZkVirtualObject_new(VirtualObjectType.zCZoneZFogDefault))
 		{

--- a/ZenKit/Vobs/ZoneMusic.cs
+++ b/ZenKit/Vobs/ZoneMusic.cs
@@ -2,7 +2,20 @@ using System;
 
 namespace ZenKit.Vobs
 {
-	public class ZoneMusic : VirtualObject
+	public interface IZoneMusic : IVirtualObject
+	{
+		bool IsEnabled { get; set; }
+		int Priority { get; set; }
+		bool IsEllipsoid { get; set; }
+		float Reverb { get; set; }
+		float Volume { get; set; }
+		bool IsLoop { get; set; }
+		bool LocalEnabled { get; set; }
+		bool DayEntranceDone { get; set; }
+		bool NightEntranceDone { get; set; }
+	}
+
+	public class ZoneMusic : VirtualObject, IZoneMusic
 	{
 		public ZoneMusic() : base(Native.ZkVirtualObject_new(VirtualObjectType.oCZoneMusic))
 		{
@@ -82,7 +95,11 @@ namespace ZenKit.Vobs
 		}
 	}
 
-	public class ZoneMusicDefault : ZoneMusic
+	public interface IZoneMusicDefault : IZoneMusic
+	{
+	}
+
+	public class ZoneMusicDefault : ZoneMusic, IZoneMusicDefault
 	{
 		public ZoneMusicDefault() : base(Native.ZkVirtualObject_new(VirtualObjectType.oCZoneMusicDefault))
 		{


### PR DESCRIPTION
> Hint: This PR leverages Option 2) Interfaces.


## Description
On our C# project, we have a Lab scene where we test certain conditions. E.g. testing door animations of a locked instance of _Door_. The base class _VirtualObject_ is already baked by an interface (_IVirtualObject_), which makes it easy to create a test class and overwrite certain behaviour. The super classes (like _Door_) are without interfaces so far. To ensure a proper way of subclassing e.g. Door with proper overwriting of functionality, we either need:
* Option 1) Every property of a subclass of VirtualObject (like Door) need to make their properties virtual so that we can overwrite them
* Option 2) Otherwise every subclass needs to be baked by an interface

## Examples


### Current behaviour
```c#
// ZenKit
class Door : VirtualObject
{
    public bool IsLocked => Native.ZkDoor_getIsLocked(Handle);
}

// Our C# project
class LabDoor : Door
{
    // Hint: New is indicator for compiler warning only. It won't affect handling below.
    public new bool IsLocked => true;
}

class Lab
{
    public void Execute()
    {
        // In our example, we instantiate a LabDoor, but in our test scenarios, we only know, that we leverage a door. LabDoor is kind of a mock. But testing normal code, we never! know if it's a Lab object.
        Door testDoor = (Door)new LabDoor();

        // If we do _not_ mark Field as virtual, we will always execute superclass Field. (Door.IsLocked)
        testDoor.IsLocked;

        // In current state, we would need to cast it back to Subclass, which we don't want when we test normal (non-Lab) code.
        ((LabDoor)testDoor).IsLocked;
    }
}
```


## Option 1) Virtual method changes

```c#
// ZenKit
class Door : VirtualObject
{
    public virtual bool IsLocked => ...
}

// Our C# project
class LabDoor : Door
{
    public override bool IsLocked => true;
}
```

## Option 2) Interface usage

```c#
// ZenKit

class IDoor : IVirtualObject
{
    bool IsLocked { get; }
}

class Door : VirtualObject, IDoor
{
    public bool IsLocked => ...
}

// Our C# project
class LabDoor : IDoor
{
    public bool IsLocked => true;
}

```

## Conclusion
* I leveraged Interface behaviour for all subclasses of VirtualObjects because - well - Composition over inheritance. (Jokes aside, the Interface way felt more transparent than _virtual_izing every method)
* I also inherited every Interface with it's parent interface (e.g. IDoor : IInteractiveObject) as it makes it easier for us to just have an IDoor object where we can fetch all the I* properties instead of casting it again)
* I executed all ZenKit.Tests. If you want me to create tests for the Interface logic, just tell me what to execute.
