### PR TITLE
fix: ITriggerScript extend ITrigger like TriggerScript is extending Trigger

### DIFF
--- a/ZenKit/Vobs/TriggerScript.cs
+++ b/ZenKit/Vobs/TriggerScript.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace ZenKit.Vobs
 {
-	public interface ITriggerScript : IVirtualObject
+	public interface ITriggerScript : ITrigger
 	{
 		string Function { get; set; }
 	}


### PR DESCRIPTION
Same behavior as e.g., IMover: ITrigger
This Interface inheritance behavior helps to use interface for all properties at runtime.